### PR TITLE
return FB total_count instead of share_count

### DIFF
--- a/lib/share-counter.rb
+++ b/lib/share-counter.rb
@@ -25,8 +25,8 @@ class ShareCounter
   end
 
   def self.facebook url
-    html = make_request "https://api.facebook.com/method/fql.query", format: "json", query: "select share_count from link_stat where url=\"#{url}\""
-    return JSON.parse(html)[0]['share_count']
+    html = make_request "https://api.facebook.com/method/fql.query", format: "json", query: "select total_count from link_stat where url=\"#{url}\""
+    return JSON.parse(html)[0]['total_count']
   end
 
   def self.linkedin url


### PR DESCRIPTION
Previous version only returned share_count.

Available counts are:
- share_count
- like_count
- comment_count
- total_count
- commentsbox_count
- comments_fbid
- click_count

I personaly don’t need more than just the total. If you need more, feel
free.
