### PR TITLE
Exception handling changes

### DIFF
--- a/lib/share-counter.rb
+++ b/lib/share-counter.rb
@@ -107,7 +107,7 @@ class ShareCounter
         sleep 2
         retry
       else
-        raise Exception
+        raise e
       end
     end
 

--- a/lib/share-counter.rb
+++ b/lib/share-counter.rb
@@ -100,7 +100,7 @@ class ShareCounter
         ? response.gsub(/\A\/\*\*\/\s+/, "").gsub(/^(.*);+\n*$/, "\\1").gsub(/^#{params[:callback]}\((.*)\)$/, "\\1") \
         : response
 
-    rescue Exception => e
+    rescue => e
       puts "Failed #{attempts} attempt(s) - #{e}"
       attempts += 1
       if attempts <= 3
@@ -116,4 +116,3 @@ class ShareCounter
 
 
 end
-


### PR DESCRIPTION
Thanks for working on this gem. I appreciate it and this is helpful to us. 

I am making a couple changes here: 

- Instead of rescuing `Exception`, I am rescuing `StandardError`. That avoids having errors like `NoMemoryError` and few other helpful errors getting rescued. It is generally a good practice to not rescue `Exception`. 

- I am also raising the exception as received from the api after the 3 failed attempts. Similar principle here, I think. It might help to be more informative to clients to receive the exception as raised by the api (than just `Exception`), and it won't force them to have to rescue `Exception` in their code. 

I don't have much experience with this but I guess that In the long run, what might help most is to have a list of specific errors being rescued (which I guess might be hard list out), and then raise one gem specific custom error class with the error message as received from the api.
