### PR TITLE
Extend ::facebook to return a hash of metrics.

### DIFF
--- a/lib/share-counter.rb
+++ b/lib/share-counter.rb
@@ -25,8 +25,8 @@ class ShareCounter
   end
 
   def self.facebook url
-    html = make_request "https://api.facebook.com/method/fql.query", format: "json", query: "select share_count from link_stat where url=\"#{url}\""
-    return JSON.parse(html)[0]['share_count']
+    html = make_request "https://api.facebook.com/method/fql.query", format: "json", query: "select commentsbox_count, click_count, total_count, comment_count, like_count, share_count from link_stat where url=\"#{url}\""
+    return JSON.parse(html)[0]
   end
 
   def self.linkedin url


### PR DESCRIPTION
Instead of just the share_counts, return a hash of all facebook metrics
in a hash.

The metrics currently include
- commentsbox_count
- click_count
- total_count
- comment_count
- like_count
- share_count

See https://github.com/ollieglass/share-counter/issues/1 and
https://github.com/ollieglass/share-counter/pull/19
